### PR TITLE
Add MobX stores as per Mike Lewis' blog post

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    "next/babel"
+  ],
+  "plugins": [
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-class-properties", { "loose": true }]
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # MobX and Next.js
 
-Example about how to initialize and use MobX stores in a Next.js app.
+Demo of using MobX stores in a Next.js app.
+
+Based on a [blog post by Mike Lewis](https://www.themikelewis.com/post/nextjs-with-mobx).

--- a/package.json
+++ b/package.json
@@ -9,8 +9,14 @@
     "start": "next start"
   },
   "dependencies": {
+    "mobx": "^5.13.0",
+    "mobx-react": "^6.1.3",
     "next": "^9.0.3",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
+    "@babel/plugin-proposal-decorators": "^7.4.4"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import App, { Container } from 'next/app';
+import { Provider } from 'mobx-react';
+
+import initializeStore from '../stores/stores';
+
+class CustomApp extends App {
+  static async getInitialProps(appContext) {
+    const mobxStore = initializeStore();
+    appContext.ctx.mobxStore = mobxStore;
+    const appProps = await App.getInitialProps(appContext);
+    return {
+      ...appProps,
+      initialMobxState: mobxStore,
+    };
+  }
+
+  constructor(props) {
+    super(props);
+    const isServer = typeof window === 'undefined';
+    this.mobxStore = isServer ? props.initialMobxState : initializeStore(props.initialMobxState);
+  }
+
+  render() {
+    const { Component, pageProps } = this.props;
+    return (
+      <Provider {...this.mobxStore}>
+        <Container>
+          <Component {...pageProps} />
+        </Container>
+      </Provider>
+    );
+  }
+}
+
+export default CustomApp;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import App, { Container } from 'next/app';
 import { Provider } from 'mobx-react';
+import { isServer } from '../utils/isServer';
 
 import initializeStore from '../stores/stores';
 
@@ -17,7 +18,6 @@ class CustomApp extends App {
 
   constructor(props) {
     super(props);
-    const isServer = typeof window === 'undefined';
     this.mobxStore = isServer ? props.initialMobxState : initializeStore(props.initialMobxState);
   }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,8 +4,16 @@ const Index = () => (
   <>
     <h1>MobX and Next.js example</h1>
     <ul>
-      <li><Link href="/post/[id]" as="/post/1"><a>Post 1</a></Link></li>
-      <li><Link href="/post/[id]" as="/post/2"><a>Post 2</a></Link></li>
+      <li>
+        <Link href='/post/[id]' as='/post/1'>
+          <a>Post 1</a>
+        </Link>
+      </li>
+      <li>
+        <Link href='/post/[id]' as='/post/2'>
+          <a>Post 2</a>
+        </Link>
+      </li>
     </ul>
   </>
 );

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,13 @@
+import Link from 'next/link';
+
 const Index = () => (
-  <h1>MobX and Next.js example</h1>
-)
+  <>
+    <h1>MobX and Next.js example</h1>
+    <ul>
+      <li><Link href="/post/[id]" as="/post/1"><a>Post 1</a></Link></li>
+      <li><Link href="/post/[id]" as="/post/2"><a>Post 2</a></Link></li>
+    </ul>
+  </>
+);
 
 export default Index;

--- a/pages/post/[id].js
+++ b/pages/post/[id].js
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+const Post = ({ post }) => (
+  <>
+    <h1>Post</h1>
+    <p>{post}</p>
+    <div><Link href="/"><a>Home</a></Link></div>
+  </>
+);
+
+Post.getInitialProps = async ({mobxStore: {postStore}, query}) => {
+  await postStore.fetch(query.id);
+  return {
+    post: postStore.post,
+  }
+}
+
+export default Post;

--- a/pages/post/[id].js
+++ b/pages/post/[id].js
@@ -4,15 +4,19 @@ const Post = ({ post }) => (
   <>
     <h1>Post</h1>
     <p>{post}</p>
-    <div><Link href="/"><a>Home</a></Link></div>
+    <div>
+      <Link href='/'>
+        <a>Home</a>
+      </Link>
+    </div>
   </>
 );
 
-Post.getInitialProps = async ({mobxStore: {postStore}, query}) => {
+Post.getInitialProps = async ({ mobxStore: { postStore }, query }) => {
   await postStore.fetch(query.id);
   return {
     post: postStore.post,
-  }
-}
+  };
+};
 
 export default Post;

--- a/pages/post/[id].js
+++ b/pages/post/[id].js
@@ -1,12 +1,15 @@
 import Link from 'next/link';
 
-const Post = ({ post }) => (
+const Post = ({ post, id }) => (
   <>
     <h1>Post</h1>
     <p>{post}</p>
     <div>
       <Link href='/'>
         <a>Home</a>
+      </Link>{' '}
+      <Link href='/post/[id]' as={`/post/${id === '1' ? '2' : '1'}`}>
+        <a>The other post</a>
       </Link>
     </div>
   </>
@@ -16,6 +19,7 @@ Post.getInitialProps = async ({ mobxStore: { postStore }, query }) => {
   await postStore.fetch(query.id);
   return {
     post: postStore.post,
+    id: query.id,
   };
 };
 

--- a/stores/PostStore.js
+++ b/stores/PostStore.js
@@ -1,0 +1,22 @@
+import { observable, action } from 'mobx';
+
+import { fetchPost } from '../utils/api';
+
+class PostStore {
+  @observable post = '';
+
+  constructor(initialData = {}) {
+    this.post = initialData.post;
+  }
+
+  async fetch(id) {
+    const response = await fetchPost(id);
+    this.setPost(response);
+  }
+
+  @action setPost(post) {
+    this.post = post;
+  }
+}
+
+export default PostStore;

--- a/stores/UIStore.js
+++ b/stores/UIStore.js
@@ -1,0 +1,11 @@
+import { observable, action } from 'mobx';
+
+class UIStore {
+  @observable searchOverlayOpen = false;
+
+  @action setSearchOverlayOpen(value) {
+    this.searchOverlayOpen = value;
+  }
+}
+
+export default UIStore;

--- a/stores/stores.js
+++ b/stores/stores.js
@@ -1,0 +1,26 @@
+import { useStaticRendering } from 'mobx-react';
+
+import PostStore from './PostStore';
+import UIStore from './UIStore';
+
+const isServer = typeof window === 'undefined';
+useStaticRendering(isServer);
+
+let store = null;
+
+export default function initializeStore(initialData = { postStore: {} }) {
+  if (isServer) {
+    return {
+      postStore: new PostStore(initialData.postStore),
+      uiStore: new UIStore(),
+    };
+  }
+  if (store === null) {
+    store = {
+      postStore: new PostStore(initialData.postStore),
+      uiStore: new UIStore(),
+    };
+  }
+
+  return store;
+}

--- a/stores/stores.js
+++ b/stores/stores.js
@@ -1,9 +1,8 @@
 import { useStaticRendering } from 'mobx-react';
-
+import { isServer } from '../utils/isServer';
 import PostStore from './PostStore';
 import UIStore from './UIStore';
 
-const isServer = typeof window === 'undefined';
 useStaticRendering(isServer);
 
 let store = null;

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,0 +1,7 @@
+export async function fetchPost(id) {
+  return new Promise(resolve =>
+    setTimeout(() => {
+      resolve(`This is post ID ${id}`);
+    }, 500)
+  );
+}

--- a/utils/isServer.js
+++ b/utils/isServer.js
@@ -1,0 +1,1 @@
+export const isServer = typeof window === 'undefined';

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,6 +255,23 @@
     "@babel/helper-create-class-features-plugin" "^7.4.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-proposal-class-properties@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz#a974cfae1e37c3110e71f3c6a2e48b8e71958cd4"
+  integrity sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.5.5"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-proposal-decorators@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.4.tgz#de9b2a1a8ab0196f378e2a82f10b6e2a36f21cc0"
+  integrity sha512-z7MpQz3XC/iQJWXH9y+MaWcLPNSMY9RQSthrLzak8R8hCj0fuyNk+Dzi9kfNe/JxxlWQ2g7wkABbgWjW36MTcw==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-decorators" "^7.2.0"
+
 "@babel/plugin-proposal-json-strings@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317"
@@ -300,6 +317,13 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz#69e1f0db34c6f5a0cf7e2b3323bf159a76c8cb7f"
   integrity sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-decorators@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz#c50b1b957dcc69e4b1127b65e1c33eef61570c1b"
+  integrity sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -2923,6 +2947,23 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mobx-react-lite@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-1.4.0.tgz#193beb5fdddf17ae61542f65ff951d84db402351"
+  integrity sha512-5xCuus+QITQpzKOjAOIQ/YxNhOl/En+PlNJF+5QU4Qxn9gnNMJBbweAdEW3HnuVQbfqDYEUnkGs5hmkIIStehg==
+
+mobx-react@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-6.1.3.tgz#ad07880ea60cdcdb2a7e2a0d54e01379710cf00a"
+  integrity sha512-eT/jO9dYIoB1AlZwI2VC3iX0gPOeOIqZsiwg7tDJV1B7Z69h+TZZL3dgOE0UeS2zoHhGeKbP+K+OLeLMnnkGnA==
+  dependencies:
+    mobx-react-lite "1.4.0"
+
+mobx@^5.13.0:
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.13.0.tgz#0fd68f10aa5ff2d146a4ed9e145b53337cfbca59"
+  integrity sha512-eSAntMSMNj0PFL705rgv+aB/z1RjNqDnFEpBe18yQVreXTWiVgIrmBUXzjnJfuba+eo4eAk6zi+/gXQkSUea8A==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR adds MobX stores as per [this blog post](https://www.themikelewis.com/post/nextjs-with-mobx). Some small differences are:

- The page demonstrating store usage uses Next.js v9 [dynamic routing](https://nextjs.org/blog/next-9#dynamic-route-segments) and is implemented in `pages/post/[id].js`.
- It does **not** use `@inject` as I think the blog post "incorrectly" adds this annotation while not making any use of it. If `PostStore.post` changed, the UI would not react to it.
     - Because of this, I saw no reason to implement the component as a class; it is a plain function component.
- The API is faked with the help of `setTimeout`.